### PR TITLE
Removes call to foundation, catches missing element selector

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,3 +1,9 @@
+//@todo once the old page is removed we can remove this codeblock
+if (typeof Foundation !== 'undefined') {
+  $(document).foundation();
+}
+
+
 $(function () {
   $('a[href*="#"]:not([href="#"])').click(function () {
     // Uncheck the overlay checkbox.

--- a/js/app.js
+++ b/js/app.js
@@ -1,13 +1,11 @@
-$(document).foundation();
-
-$(function() {
-  $('a[href*="#"]:not([href="#"])').click(function() {
+$(function () {
+  $('a[href*="#"]:not([href="#"])').click(function () {
     // Uncheck the overlay checkbox.
     $('#hamburger').prop("checked", false);
 
-    if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {
+    if (location.pathname.replace(/^\//, '') == this.pathname.replace(/^\//, '') && location.hostname == this.hostname) {
       var target = $(this.hash);
-      target = target.length ? target : $('[name=' + this.hash.slice(1) +']');
+      target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');
       if (target.length) {
         $('html, body').animate({
           scrollTop: target.offset().top

--- a/js/sessions.js
+++ b/js/sessions.js
@@ -45,6 +45,7 @@ function massageData(array) {
 
 function createSessionList(dayId, sessions) {
     const dayElement = document.querySelector(`#${dayId}`);
+    if (!dayElement) { return; }
     sessions.forEach(session => {
         let sessionElement = document.createElement('div');
         sessionElement.className = 'session';


### PR DESCRIPTION
We don't need foundation so I removed the call to it.

Currently we're commenting out the sessions sections so the selector throws an error. This puts a catch so even when the sessions aren't available we don't get console errors.